### PR TITLE
Add functionality

### DIFF
--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -1,0 +1,8 @@
+name: PHP syntax check
+
+on: [push, pull_request]
+
+jobs:
+
+  php-syntax-check:
+    uses: dxw/govpress-workflow-php-syntax-check/.github/workflows/php-syntax-check.yml@v0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+[1.0.0] - 2025-02-28
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Nelio AB On Staging
+
+The default behaviour of the Nelio AB Testing plugin is to disable some of its functionality on environments whose URL includes the string "staging".
+
+This makes sense if you e.g. have a paid-for license key in use on prod that is mirrored to staging, but don't want to burn your usage allocation on staging. But for most of our clients, where we won't have an API key in place on staging, it just means they can't fully test AB testing in the staging environment.
+
+This plugin removes the staging restriction, so all functionality works on staging environments.

--- a/index.php
+++ b/index.php
@@ -15,3 +15,7 @@
  * Author: dxw
  * Version: 1.0.0
  */
+
+add_filter('nab_staging_urls', function () {
+	return [];
+});

--- a/index.php
+++ b/index.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * WordPress Plugin
+ *
+ * @package     WordPressPlugin
+ * @author      dxw
+ * @copyright   2020
+ * @license     MIT
+ *
+ * @wordpress-plugin
+ * Plugin Name: Nelio AB On Staging
+ * Plugin URI: https://github.com/dxw/nelio-ab-on-staging
+ * Description: Enable full Nelio AB Testing functionality on staging environments. Not required on prod.
+ * Author: dxw
+ * Version: 1.0.0
+ */


### PR DESCRIPTION
This PR adds the simple functionality of this plugin, plus documentation.

It hooks into Nelio AB's `nab_staging_urls` filter to return an empty array, so that no URLs will ever return true when Nelio AB is trying to detect if they represent a staging environment. This means the full Nelio AB functionality will be available for testing on staging when we use this plugin alongside Nelio AB.

Because the code is so brief and simple, I haven't included tests/linting to keep the repo lightweight, but a PHP syntax check does run in CI.

## How to test

It's not possible to test the exact behaviour of this plugin as-is on localhost, but we can do something that indicates it's behaving as expected more generally:

1. Checkout a repo that is using Nelio AB (e.g. NAO) and activate the Nelio AB Testing plugin
2. It's overview page (http://localhost/wp-admin/admin.php?page=nelio-ab-testing-overview) should not indicate that the environment is recognised as staging
3. Clone this repo, and this branch, into the project's `wp-content/plugins` folder
4. Edit this plugin's index.php so line 20 reads `return ['local'];`
5. The overview page should now contain a message indicating that the site has been recognised as staging
6. Run `php -l index.php` inside the plugin folder to syntax check the PHP